### PR TITLE
Prevent concurrent speed tests

### DIFF
--- a/lib/blocs/monitoramento/monitoramento_bloc.dart
+++ b/lib/blocs/monitoramento/monitoramento_bloc.dart
@@ -66,6 +66,10 @@ class MonitoramentoBloc extends Bloc<MonitoramentoEvent, MonitoramentoState> {
       return;
     }
 
+    if (_speedTest.isTestInProgress()) {
+      await _speedTest.cancelTest();
+    }
+
     _iniciarTesteVelocidade();
   }
 


### PR DESCRIPTION
## Summary
- cancel active internet speed tests before starting new ones

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb02a2ecc832298f3670dfe7ab125